### PR TITLE
fix: added extra case for processing single char prefixes of the callsign

### DIFF
--- a/src/JTEncode.cpp
+++ b/src/JTEncode.cpp
@@ -997,20 +997,20 @@ void JTEncode::wspr_bit_packing(uint8_t * c)
 			strncpy(prefix, callsign, slash_pos);
 			strncpy(base_call, callsign + slash_pos + 1, 7);
 
-      if (prefix[1] == ' ' || prefix[1] == 0) 
-      {
-        prefix[3] = 0;
-        prefix[2] = prefix[0];
-        prefix[1] = ' ';
-        prefix[0] = ' ';
-
-      } else if (prefix[2] == ' ' || prefix[2] == 0) 
-      {
-        prefix[3] = 0;
-        prefix[2] = prefix[1];
-        prefix[1] = prefix[0];
-        prefix[0] = ' ';
-      }
+		      if (prefix[1] == ' ' || prefix[1] == 0) 
+		      {
+		        prefix[3] = 0;
+		        prefix[2] = prefix[0];
+		        prefix[1] = ' ';
+		        prefix[0] = ' ';
+		
+		      } else if (prefix[2] == ' ' || prefix[2] == 0) 
+		      {
+		        prefix[3] = 0;
+		        prefix[2] = prefix[1];
+		        prefix[1] = prefix[0];
+		        prefix[0] = ' ';
+		      }
 
 			for(uint8_t i = 0; i < 6; i++)
 			{

--- a/src/JTEncode.cpp
+++ b/src/JTEncode.cpp
@@ -997,14 +997,18 @@ void JTEncode::wspr_bit_packing(uint8_t * c)
 			strncpy(prefix, callsign, slash_pos);
 			strncpy(base_call, callsign + slash_pos + 1, 7);
 
-			if(prefix[2] == ' ' || prefix[2] == 0)
-			{
-				// Right align prefix
-				prefix[3] = 0;
-				prefix[2] = prefix[1];
-				prefix[1] = prefix[0];
-				prefix[0] = ' ';
-			}
+      if (prefix[1] == ' ' || prefix[1] == 0) {
+        prefix[3] = 0;
+        prefix[2] = prefix[0];
+        prefix[1] = ' ';
+        prefix[0] = ' ';
+
+      } else if (prefix[2] == ' ' || prefix[2] == 0) {
+        prefix[3] = 0;
+        prefix[2] = prefix[1];
+        prefix[1] = prefix[0];
+        prefix[0] = ' ';
+      }
 
 			for(uint8_t i = 0; i < 6; i++)
 			{

--- a/src/JTEncode.cpp
+++ b/src/JTEncode.cpp
@@ -997,13 +997,15 @@ void JTEncode::wspr_bit_packing(uint8_t * c)
 			strncpy(prefix, callsign, slash_pos);
 			strncpy(base_call, callsign + slash_pos + 1, 7);
 
-      if (prefix[1] == ' ' || prefix[1] == 0) {
+      if (prefix[1] == ' ' || prefix[1] == 0) 
+      {
         prefix[3] = 0;
         prefix[2] = prefix[0];
         prefix[1] = ' ';
         prefix[0] = ' ';
 
-      } else if (prefix[2] == ' ' || prefix[2] == 0) {
+      } else if (prefix[2] == ' ' || prefix[2] == 0) 
+      {
         prefix[3] = 0;
         prefix[2] = prefix[1];
         prefix[1] = prefix[0];

--- a/src/JTEncode.cpp
+++ b/src/JTEncode.cpp
@@ -997,20 +997,20 @@ void JTEncode::wspr_bit_packing(uint8_t * c)
 			strncpy(prefix, callsign, slash_pos);
 			strncpy(base_call, callsign + slash_pos + 1, 7);
 
-		      if (prefix[1] == ' ' || prefix[1] == 0) 
-		      {
-		        prefix[3] = 0;
-		        prefix[2] = prefix[0];
-		        prefix[1] = ' ';
-		        prefix[0] = ' ';
+		       if (prefix[1] == ' ' || prefix[1] == 0) 
+		       {
+			        prefix[3] = 0;
+			        prefix[2] = prefix[0];
+			        prefix[1] = ' ';
+			        prefix[0] = ' ';
 		
-		      } else if (prefix[2] == ' ' || prefix[2] == 0) 
-		      {
-		        prefix[3] = 0;
-		        prefix[2] = prefix[1];
-		        prefix[1] = prefix[0];
-		        prefix[0] = ' ';
-		      }
+		       } else if (prefix[2] == ' ' || prefix[2] == 0) 
+		       {
+			        prefix[3] = 0;
+			        prefix[2] = prefix[1];
+			        prefix[1] = prefix[0];
+			        prefix[0] = ' ';
+		       }
 
 			for(uint8_t i = 0; i < 6; i++)
 			{


### PR DESCRIPTION
Added an extra case into the prefix processing as suggested by https://github.com/pe0fko on https://github.com/etherkit/JTEncode/issues/29.

Now it works for encoding callsigns like: M/9A3ICE.

I also checked with MM/9A3ICE which still works as intended.

Tested with WSJTX v2.5.4

Thanks!

Ivica
9A3ICE